### PR TITLE
Change description <div> to <pre> to fix formatting

### DIFF
--- a/Server/ItemPageTemplate.html
+++ b/Server/ItemPageTemplate.html
@@ -141,7 +141,7 @@
 			<div class="detailsContainer" id="details">
 				<div class="details" id="descriptionBlock">
 					<h3>Description</h3>
-					<div id="description">{description}</div>
+					<pre id="description">{description}</pre>
 				</div>
 				<div class="details" id="listBlock">
 					<h3>Materials List</h3>

--- a/Server/item.html
+++ b/Server/item.html
@@ -139,7 +139,7 @@
 			<div class="detailsContainer" id="details">
 				<div class="details" id="descriptionBlock">
 					<h3>Description</h3>
-					<div id="description">This is a strange redstone door that works by displaying a question in the form of an item in the dropper with a button on it. then dropping the item in a filter line. that is locked by the lecturn. The book in the lecturn must have 32 pages for this to work.The answer is in the book the player submits their answer by pushing the button for that question. The concept is inspired by the Ravenclaw common room password.</div>
+					<pre id="description">This is a strange redstone door that works by displaying a question in the form of an item in the dropper with a button on it. then dropping the item in a filter line. that is locked by the lecturn. The book in the lecturn must have 32 pages for this to work.The answer is in the book the player submits their answer by pushing the button for that question. The concept is inspired by the Ravenclaw common room password.</pre>
 				</div>
 				<div class="details" id="listBlock">
 					<h3>Materials List</h3>

--- a/Server/test.html
+++ b/Server/test.html
@@ -139,7 +139,7 @@
 			<div class="detailsContainer" id="details">
 				<div class="details" id="descriptionBlock">
 					<h3>Description</h3>
-					<div id="description">This is a strange redstone door that works by displaying a question in the form of an item in the dropper with a button on it. then dropping the item in a filter line. that is locked by the lecturn. The book in the lecturn must have 32 pages for this to work.The answer is in the book the player submits their answer by pushing the button for that question. The concept is inspired by the Ravenclaw common room password.</div>
+					<pre id="description">This is a strange redstone door that works by displaying a question in the form of an item in the dropper with a button on it. then dropping the item in a filter line. that is locked by the lecturn. The book in the lecturn must have 32 pages for this to work.The answer is in the book the player submits their answer by pushing the button for that question. The concept is inspired by the Ravenclaw common room password.</pre>
 				</div>
 				<div class="details" id="listBlock">
 					<h3>Materials List</h3>

--- a/Server/tmp/3aa08a32-c35e-474a-959d-d4c71837145c/item.html
+++ b/Server/tmp/3aa08a32-c35e-474a-959d-d4c71837145c/item.html
@@ -139,7 +139,7 @@
 			<div class="detailsContainer" id="details">
 				<div class="details" id="descriptionBlock">
 					<h3>Description</h3>
-					<div id="description">This is a strange redstone door that works by displaying a question in the form of an item in the dropper with a button on it. then dropping the item in a filter line. that is locked by the lecturn. The book in the lecturn must have 32 pages for this to work.The answer is in the book the player submits their answer by pushing the button for that question. The concept is inspired by the Ravenclaw common room password.</div>
+					<pre id="description">This is a strange redstone door that works by displaying a question in the form of an item in the dropper with a button on it. then dropping the item in a filter line. that is locked by the lecturn. The book in the lecturn must have 32 pages for this to work.The answer is in the book the player submits their answer by pushing the button for that question. The concept is inspired by the Ravenclaw common room password.</pre>
 				</div>
 				<div class="details" id="listBlock">
 					<h3>Materials List</h3>

--- a/client/Buildings.html
+++ b/client/Buildings.html
@@ -103,7 +103,7 @@
 	<div class="detailsContainer" id="details">
 		<div class="details" id="descriptionBlock">
 			<h3>Description</h3>
-			<div id="description"></div>
+			<pre id="description"></pre>
 		</div>
 		<div class="details" id="listBlock">
 			<h3>Materials List</h3>

--- a/client/Farms.html
+++ b/client/Farms.html
@@ -103,7 +103,7 @@
 	<div class="detailsContainer" id="details">
 		<div class="details" id="descriptionBlock">
 			<h3>Description</h3>
-			<div id="description"></div>
+			<pre id="description"></pre>
 		</div>
 		<div class="details" id="listBlock">
 			<h3>Materials List</h3>

--- a/client/Flying.html
+++ b/client/Flying.html
@@ -103,7 +103,7 @@
 	<div class="detailsContainer" id="details">
 		<div class="details" id="descriptionBlock">
 			<h3>Description</h3>
-			<div id="description"></div>
+			<pre id="description"></pre>
 		</div>
 		<div class="details" id="listBlock">
 			<h3>Materials List</h3>

--- a/client/Furnaces.html
+++ b/client/Furnaces.html
@@ -103,7 +103,7 @@
 	<div class="detailsContainer" id="details">
 		<div class="details" id="descriptionBlock">
 			<h3>Description</h3>
-			<div id="description"></div>
+			<pre id="description"></pre>
 		</div>
 		<div class="details" id="listBlock">
 			<h3>Materials List</h3>

--- a/client/ItemPageTemplate.html
+++ b/client/ItemPageTemplate.html
@@ -140,7 +140,7 @@
 			<div class="detailsContainer" id="details">
 				<div class="details" id="descriptionBlock">
 					<h3>Description</h3>
-					<div id="description">{description}</div>
+					<pre id="description">{description}</pre>
 				</div>
 				<div class="details" id="listBlock">
 					<h3>Materials List</h3>

--- a/client/Misc.html
+++ b/client/Misc.html
@@ -103,7 +103,7 @@
 	<div class="detailsContainer" id="details">
 		<div class="details" id="descriptionBlock">
 			<h3>Description</h3>
-			<div id="description"></div>
+			<pre id="description"></pre>
 		</div>
 		<div class="details" id="listBlock">
 			<h3>Materials List</h3>

--- a/client/Redstone.html
+++ b/client/Redstone.html
@@ -103,7 +103,7 @@
 	<div class="detailsContainer" id="details">
 		<div class="details" id="descriptionBlock">
 			<h3>Description</h3>
-			<div id="description"></div>
+			<pre id="description"></pre>
 		</div>
 		<div class="details" id="listBlock">
 			<h3>Materials List</h3>

--- a/client/Statues.html
+++ b/client/Statues.html
@@ -103,7 +103,7 @@
 	<div class="detailsContainer" id="details">
 		<div class="details" id="descriptionBlock">
 			<h3>Description</h3>
-			<div id="description"></div>
+			<pre id="description"></pre>
 		</div>
 		<div class="details" id="listBlock">
 			<h3>Materials List</h3>

--- a/client/Storage.html
+++ b/client/Storage.html
@@ -103,7 +103,7 @@
 	<div class="detailsContainer" id="details">
 		<div class="details" id="descriptionBlock">
 			<h3>Description</h3>
-			<div id="description"></div>
+			<pre id="description"></pre>
 		</div>
 		<div class="details" id="listBlock">
 			<h3>Materials List</h3>

--- a/client/Terrain.html
+++ b/client/Terrain.html
@@ -103,7 +103,7 @@
 	<div class="detailsContainer" id="details">
 		<div class="details" id="descriptionBlock">
 			<h3>Description</h3>
-			<div id="description"></div>
+			<pre id="description"></pre>
 		</div>
 		<div class="details" id="listBlock">
 			<h3>Materials List</h3>

--- a/client/Villager.html
+++ b/client/Villager.html
@@ -103,7 +103,7 @@
 	<div class="detailsContainer" id="details">
 		<div class="details" id="descriptionBlock">
 			<h3>Description</h3>
-			<div id="description"></div>
+			<pre id="description"></pre>
 		</div>
 		<div class="details" id="listBlock">
 			<h3>Materials List</h3>

--- a/client/index.html
+++ b/client/index.html
@@ -103,7 +103,7 @@
 	<div class="detailsContainer" id="details">
 		<div class="details" id="descriptionBlock">
 			<h3>Description</h3>
-			<div id="description"></div>
+			<pre id="description"></pre>
 		</div>
 		<div class="details" id="listBlock">
 			<h3>Materials List</h3>


### PR DESCRIPTION
Submission descriptions display in a single line even if they are multi-line. Using `<pre>` fixes this.
With `<div>`:
![image](https://github.com/RavinMaddHatter/structuraWeb/assets/116475184/a542eebe-6482-44b2-8d2e-83be5834e2cf)
With `<pre>`:
![image](https://github.com/RavinMaddHatter/structuraWeb/assets/116475184/f91e37db-0737-4cde-947e-ce3be06cb7f9)